### PR TITLE
Bring GitHub repo up to 2.5.3.

### DIFF
--- a/ClickToPlugin.safariextension/Info.plist
+++ b/ClickToPlugin.safariextension/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5.2</string>
+	<string>2.5.3</string>
 	<key>CFBundleVersion</key>
-	<string>29</string>
+	<string>30</string>
 	<key>Chrome</key>
 	<dict>
 		<key>Global Page</key>

--- a/ClickToPlugin.safariextension/global.js
+++ b/ClickToPlugin.safariextension/global.js
@@ -48,7 +48,7 @@ if(settings.version < 29) {
 	settings.killer = settings.additionalScripts;
 	settings.removeItem("additionalScripts");
 }
-settings.version = 29;
+settings.version = 30;
 
 // LOCALIZATION
 localize(GLOBAL_STRINGS, settings.language);


### PR DESCRIPTION
I noticed that the version in GitHub is 2.5.2 whereas the released version is 2.5.3. This brings GitHub up to the same version (actually I may have swapped the case of mediaPlayer.js from the official 2.5.3, but it's inconsequential—as long as it's internally consistent).
