### PR TITLE
Fix for the official Blip.tv killer – It broke a couple of days ago.

### DIFF
--- a/ClickToPlugin.safariextension/killers/Blip.js
+++ b/ClickToPlugin.safariextension/killers/Blip.js
@@ -9,7 +9,7 @@ addKiller("Blip", {
 		var isEmbed = false;
 		var url = parseFlashVariables(data.params.flashvars).file;
 		if(!url) {
-			var match = /[?&]file=([^&]*)/.exec(data.src);
+			var match = /[?&#]file=([^&]*)/.exec(data.src);
 			if(!match) return;
 			url = match[1];
 			isEmbed = true;


### PR DESCRIPTION
Hi,

The Blip.tv killer broke a couple of days ago, but fortunately it's been trivial to fix. Please consider adding the fix, so that the killer that ships with ClickToPlugin works again.

Cheers,
Georg
