### PR TITLE
Fix a case-sensitivity issue in references to mediaPlayer.js.

### DIFF
--- a/ClickToPlugin.safariextension/Info.plist
+++ b/ClickToPlugin.safariextension/Info.plist
@@ -28,7 +28,7 @@
 			<key>Start</key>
 			<array>
 				<string>functions.js</string>
-				<string>MediaPlayer.js</string>
+				<string>mediaPlayer.js</string>
 				<string>main.js</string>
 			</array>
 		</dict>

--- a/ClickToPlugin.safariextension/global.js
+++ b/ClickToPlugin.safariextension/global.js
@@ -319,7 +319,7 @@ function switchOff() {
 function switchOn() {
 	safari.extension.removeContentScripts();
 	safari.extension.addContentScriptFromURL(safari.extension.baseURI + "functions.js");
-	safari.extension.addContentScriptFromURL(safari.extension.baseURI + "MediaPlayer.js");
+	safari.extension.addContentScriptFromURL(safari.extension.baseURI + "mediaPlayer.js");
 	safari.extension.addContentScriptFromURL(safari.extension.baseURI + "main.js");
 	safari.extension.addContentScript(localizationScript, [], [], false);
 	updateGlobalShortcuts();


### PR DESCRIPTION
Without this change I see errors in the console about Safari failing to find the MediaPlayer function, due to MediaPlayer.js failing to load.
