### PR TITLE
Switch from assigning values containing "!important" using the CSS objec...

### DIFF
--- a/ClickToPlugin.safariextension/main.js
+++ b/ClickToPlugin.safariextension/main.js
@@ -222,8 +222,8 @@ function handleBeforeLoadEvent(event) {
 	var placeholder = document.createElement("div");
 	if(settings.showTooltip) placeholder.title = response.src; // tooltip
 	placeholder.className = "CTPnoimage CTPplaceholder";
-	placeholder.style.width = data.width + "px !important";
-	placeholder.style.height = data.height + "px !important";
+	placeholder.style.setProperty("width", data.width + "px", "important");
+	placeholder.style.setProperty("height", data.height + "px", "important");
 	if(response.isInvisible) placeholder.classList.add("CTPinvisible");
 	
 	// Copy CSS box & positioning properties that have an effect on page layout
@@ -244,7 +244,7 @@ function handleBeforeLoadEvent(event) {
 		if(stack === undefined || stack.parentNode !== document.body) {
 			stack = document.createElement("div");
 			stack.id = "CTPstack";
-			stack.style.display = "none !important"; // in case the extension is disabled
+			stack.style.setProperty("display", "none", "important"); // in case the extension is disabled
 			stack.innerHTML = "<div><div></div></div>";
 			document.body.appendChild(stack);
 		}
@@ -272,7 +272,7 @@ function handleBeforeLoadEvent(event) {
 	
 	// Fill the placeholder
 	placeholder.innerHTML = "<div class=\"CTPplaceholderContainer\"><div class=\"CTPlogoContainer CTPnodisplay\"><div class=\"CTPlogo\"></div><div class=\"CTPlogo CTPinset\"></div></div></div>";
-	placeholder.firstChild.style.opacity = settings.opacity + " !important";
+	placeholder.firstChild.style.setProperty("opacity", settings.opacity, "important");
 	
 	// Display the badge
 	if(_[data.elementID].plugin) displayBadge(data.elementID, _[data.elementID].plugin);
@@ -346,8 +346,8 @@ function handleMediaData(elementID, mediaData) {
 function initMedia(elementID, media) {
 	// Set poster & tooltip
 	if(settings.showPoster && media.poster) {
-		_[elementID].placeholder.firstChild.style.opacity = "1 !important";
-		_[elementID].placeholder.firstChild.style.backgroundImage = "url('" + media.poster + "') !important";
+		_[elementID].placeholder.firstChild.style.setProperty("opacity", "1", "important");
+		_[elementID].placeholder.firstChild.style.setProperty("backgroundImage", "url('" + media.poster + "')", "important");
 		_[elementID].placeholder.classList.remove("CTPnoimage");
 	}
 	if(media.title) _[elementID].placeholder.title = media.title;

--- a/ClickToPlugin.safariextension/mediaPlayer.js
+++ b/ClickToPlugin.safariextension/mediaPlayer.js
@@ -77,10 +77,10 @@ MediaPlayer.prototype.init = function(style) {
 	this.container.appendChild(this.mediaElement);
 	
 	// Set styles
-	this.container.style.width = this.width + "px !important";
-	this.container.style.height = this.height + "px !important";
-	this.mediaElement.style.width = this.width + "px !important";
-	this.mediaElement.style.height = this.height + "px !important";
+	this.container.style.setProperty("width", this.width + "px", "important");
+	this.container.style.setProperty("height", this.height + "px", "important");
+	this.mediaElement.style.setProperty("width", this.width + "px", "important");
+	this.mediaElement.style.setProperty("height", this.height + "px", "important");
 	applyCSS(this.container, style, ["position", "top", "right", "bottom", "left", "z-index", "clear", "float", "vertical-align", "margin-top", "margin-right", "margin-bottom", "margin-left", "-webkit-margin-before-collapse", "-webkit-margin-after-collapse"]);
 	
 	// Set volume
@@ -177,7 +177,7 @@ MediaPlayer.prototype.load = function(track, source, autoplay, updatePoster) {
 	if(updatePoster) {
 		// Remove poster early so that it doesn't show before the new poster is loaded
 		this.mediaElement.removeAttribute("poster");
-		this.container.style.backgroundImage = "none !important";
+		this.container.style.setProperty("backgroundImage", "none", "important");
 	}
 	// Pause first to prevent undesirable sound quirks
 	// Conditional needed, otherwise Webkit fails to reset autoplaying flag on initial load
@@ -197,7 +197,7 @@ MediaPlayer.prototype.load = function(track, source, autoplay, updatePoster) {
 MediaPlayer.prototype.updatePoster = function() {
 	if(!this.playlist[this.currentTrack].poster) return;
 	if(this.playlist[this.currentTrack].sources[this.currentSource].isAudio) {
-		this.container.style.backgroundImage = "url('" + this.playlist[this.currentTrack].poster + "') !important";
+		this.container.style.setProperty("backgroundImage", "url('" + this.playlist[this.currentTrack].poster + "')", "important");
 	} else {
 		this.mediaElement.poster = this.playlist[this.currentTrack].poster;
 	}
@@ -421,9 +421,9 @@ MediaPlayer.prototype.initSourceSelector = function() {
 		},
 		
 		"attachTo": function(element) {
-			container.style.WebkitTransitionProperty = "none !important";
+			container.style.setProperty("WebkitTransitionProperty", "none", "important");
 			element.appendChild(container);
-			setTimeout(function() {container.style.WebkitTransitionProperty = "opacity !important";}, 0);
+			setTimeout(function() {container.style.setProperty("WebkitTransitionProperty", "opacity", "important");}, 0);
 		},
 		
 		"update": function() {
@@ -478,8 +478,8 @@ MediaPlayer.prototype.initTrackSelector = function() {
 		player.shadowDOM.volumeSliderContainer.style.display = "none";
 		player.shadowDOM.muteButton.style.display = "none";
 		player.shadowDOM.timelineContainer.style.display = "none";
-		container.style.left = leftOffset + "px !important";
-		container.style.width = (player.width - leftOffset) + "px !important";
+		container.style.setProperty("left", leftOffset + "px", "important");
+		container.style.setProperty("width", (player.width - leftOffset) + "px", "important");
 		container.classList.remove("CTPhidden");
 	};
 	
@@ -495,8 +495,8 @@ MediaPlayer.prototype.initTrackSelector = function() {
 	
 	var show = function() {
 		player.shadowDOM.controlsPanel.style.display = "none";
-		container.style.left = "0px !important";
-		container.style.width = "inherit !important";
+		container.style.setProperty("left", "0px", "important");
+		container.style.setProperty("width", "inherit", "important");
 		container.classList.remove("CTPhidden");
 		selector.focus();
 	};


### PR DESCRIPTION
...t model to using setProperty explicitly to avoid the media player layout breaking with WebKit >= r102262.

Until WebKit r102262, it was incorrectly allowing "!important" in CSS values set via the CSSOM (http://webkit.org/b/73941). ClickToPlugin's HTML5 media player used this pattern in numerous locations, and therefore suffered from broken layout in WebKit versions with the fix for bug 73941. The "important" priority can instead be specified when setting the value via setProperty.
