### PR TITLE
A fix that allows to start the airplay streaming, where the local player has left off.

### DIFF
--- a/ClickToPlugin.safariextension/MediaPlayer.js
+++ b/ClickToPlugin.safariextension/MediaPlayer.js
@@ -33,8 +33,14 @@ MediaPlayer.prototype.openInQTP = function(source) {
 MediaPlayer.prototype.airplay = function(source) {
 	if(this.mediaElement) this.mediaElement.pause();
 	var anchor = document.createElement("a");
-	anchor.href = this.getURL(source);
-	safari.self.tab.dispatchMessage("airplay", anchor.href);
+	anchor.href = this.getURL(source);	
+	var position = 0.0;
+	if(this.mediaElement)
+	{
+		position = this.mediaElement.currentTime / this.mediaElement.duration;
+	}
+	var airplayMessage = [anchor.href, position];
+	safari.self.tab.dispatchMessage("airplay", airplayMessage);
 };
 
 MediaPlayer.prototype.viewOnSite = function() {

--- a/ClickToPlugin.safariextension/support.js
+++ b/ClickToPlugin.safariextension/support.js
@@ -42,7 +42,9 @@ function openTab(url) {
 	tab.url = url;
 }
 
-function airplay(url) {
+function airplay(airplayMessage) {
+	var url = airplayMessage[0];
+	var position = airplayMessage[1];
 	var xhr = new XMLHttpRequest();
 	var port = ":7000";
 	if(/:\d+$/.test(settings.airplayHostname)) port = "";
@@ -62,7 +64,7 @@ function airplay(url) {
 		}, 1000);
 	}, false);
 	xhr.setRequestHeader("Content-Type", "text/parameters");
-	xhr.send("Content-Location: " + url + "\nStart-Position: 0\n");
+	xhr.send("Content-Location: " + url + "\nStart-Position: " + position + "\n");
 }
 
 function matchList(list, string) {


### PR DESCRIPTION
I found that whenever I am halfway through watching the movie on my laptop, and want to finish watching on my Apple TV, the "Send via Airplay" ignores the fact of where the playhead has been, and starts off from the beginning. This sort of behaviour was especially annoying with long videos, where jumping to the right position on the Apple TV could take some time.

This fix passes the the current position of the player to the airplay call, thus streaming starts where you have left off.
